### PR TITLE
[PROPOSAL] Use Google Test library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ext/googletest"]
+	path = ext/googletest
+	url = git@github.com:google/googletest.git

--- a/exampletests/asserts.h
+++ b/exampletests/asserts.h
@@ -1,0 +1,16 @@
+#include "gtest/gtest.h"
+
+testing::AssertionResult isAddress6Match(const uint16_t * actual, const uint16_t * expected)
+{
+    for ( int i = 0; i < 8; ++i ) {
+        uint16_t fragActual = actual[i];
+        uint16_t fragExpected = htons(expected[i]);
+
+        if(fragActual != fragExpected)
+            return testing::AssertionFailure()
+                << "ip fragment " << (i+1) << " does not match "
+                << fragActual << " != " << fragExpected;
+    }
+
+    return testing::AssertionSuccess();
+}

--- a/exampletests/test_address.cpp
+++ b/exampletests/test_address.cpp
@@ -1,0 +1,113 @@
+#include "yojimbo.h"
+#include "gtest/gtest.h"
+#include "asserts.h"
+
+using namespace yojimbo;
+
+
+TEST(Address, CreateIpv4Direct)
+{
+    Address address( 127, 0, 0, 1, 1000 );
+
+    ASSERT_TRUE( address.IsValid() );
+    ASSERT_EQ( address.GetType(), ADDRESS_IPV4 );
+    ASSERT_EQ( address.GetPort(), 1000 );
+    ASSERT_EQ( address.GetAddress4(), (uint32_t)0x100007f );
+}
+
+TEST(Address, CreateIpv6Direct)
+{
+    const uint16_t addr[] = { 0xFE80, 0x0000, 0x0000, 0x0000, 0x0202, 0xB3FF, 0xFE1E, 0x8329 };
+
+    Address address( addr[0], addr[1], addr[2], addr[3],
+                     addr[4], addr[5], addr[6], addr[7] );
+
+    ASSERT_TRUE( address.IsValid() );
+    ASSERT_EQ( address.GetType(), ADDRESS_IPV6 );
+    ASSERT_EQ( address.GetPort(), 0 );
+    ASSERT_TRUE( isAddress6Match( address.GetAddress6(), addr));
+}
+
+TEST(Address, CreateFromString)
+{
+    Address address( "127.0.0.1" );
+
+    ASSERT_TRUE( address.IsValid() );
+    ASSERT_EQ( address.GetType(), ADDRESS_IPV4 );
+    ASSERT_EQ( address.GetPort(), 0 );
+    ASSERT_EQ( address.GetAddress4(), (uint32_t)0x100007f );
+}
+
+
+TEST(Address, Clear)
+{
+    Address address( 127, 0, 0, 1, 1000 );
+    address.Clear();
+
+    ASSERT_FALSE( address.IsValid() );
+    ASSERT_EQ( address.GetType(), ADDRESS_NONE );
+    ASSERT_EQ( address.GetPort(), 0 );
+    // ASSERT_EQ( address.GetAddress4(), (uint32_t)0x0 );
+}
+
+TEST(Address, ToString)
+{
+    char buffer[MaxAddressLength];
+
+    Address address ( 127, 0, 0, 1, 1000 );
+    ASSERT_STREQ( address.ToString( buffer, MaxAddressLength ), "127.0.0.1:1000" );
+
+    address = Address( 127, 0, 0, 1 );
+    ASSERT_STREQ( address.ToString( buffer, MaxAddressLength ), "127.0.0.1" );
+
+    address = Address( 255, 255, 255, 255, 65535 );
+    ASSERT_STREQ( address.ToString( buffer, MaxAddressLength ), "255.255.255.255:65535" );
+
+    address = Address( 10, 24, 168, 192, 3000 );
+    ASSERT_STREQ( address.ToString( buffer, MaxAddressLength ), "10.24.168.192:3000" );
+
+    address = Address( 0, 0, 0, 0, 0, 0, 0, 1 );
+    ASSERT_STREQ( address.ToString( buffer, MaxAddressLength ), "::1" );
+
+    address = Address( 0xFE80, 0x0000, 0x0000, 0x0000, 0x0202, 0xB3FF, 0xFE1E, 0x8329, 0xFE80 );
+    ASSERT_STREQ( address.ToString( buffer, MaxAddressLength ), "[fe80::202:b3ff:fe1e:8329]:65152" );
+}
+
+TEST(Address, IsLinkLocal)
+{
+    Address address( 0xfe80, 0, 0, 0, 0, 0, 0, 0);
+    ASSERT_TRUE( address.IsLinkLocal() );
+
+    address = Address( 0, 0, 0, 0, 0, 0, 0, 0);
+    ASSERT_FALSE( address.IsLinkLocal() );
+}
+
+TEST(Address, IsSiteLocal)
+{
+    Address address( 0xFEC0, 0, 0, 0, 0, 0, 0, 0, 0);
+    ASSERT_TRUE( address.IsSiteLocal() );
+
+    address = Address( 0, 0, 0, 0, 0, 0, 0, 0);
+    ASSERT_FALSE( address.IsSiteLocal() );
+}
+
+TEST(Address, IsMulticast)
+{
+    Address address( 0xFF00, 0, 0, 0, 0, 0, 0, 0, 0);
+    ASSERT_TRUE( address.IsMulticast() );
+
+    address = Address( 0, 0, 0, 0, 0, 0, 0, 0);
+    ASSERT_FALSE( address.IsMulticast() );
+}
+
+TEST(Address, IsLoopback)
+{
+    Address address( 127, 0, 0, 1, 1000 );
+    ASSERT_TRUE( address.IsLoopback() );
+
+    address = Address( 0, 0, 0, 0, 0, 0, 0, 1 );
+    ASSERT_TRUE( address.IsLoopback() );
+
+    address = Address( 10, 0, 0, 1, 1000 );
+    ASSERT_FALSE( address.IsLoopback() );
+}

--- a/premake5.lua
+++ b/premake5.lua
@@ -82,6 +82,18 @@ project "simple_messages"
     files { "tests/simple_messages.cpp", "tests/shared.h" }
     links { "yojimbo" }
 
+project "gtest"
+    kind "StaticLib"
+    files { "ext/googletest/googletest/src/gtest-all.cc", "ext/googletest/googletest/src/gtest_main.cc" }
+    includedirs { "ext/googletest/googletest", "ext/googletest/googletest/include" }
+
+project "exampletests"
+    targetname "exampletests"
+    files { "exampletests/*.cpp" }
+    links { "gtest", "yojimbo" }
+    includedirs {"src", "ext/googletest/googletest/include"}
+
+
 if not os.is "windows" then
 
     -- MacOSX and Linux.


### PR DESCRIPTION
I want to propose using google-test as the official testing framework here before I do any more work on this branch. *(disclaimer: I'm a bit rough on my C++, but I'm fixing that)*

I think there are some clear benefits, especially for a library which is so heavily used and supported. This is a really rough proposal. I would finish importing over the rest of the tests piecemeal before killing the old tests and renaming the old directory.

*Organization*
A testing framework will organize tests into clearly separate test cases. Looking through the tests right now, it's difficult to see what is actually tested, and what is not tested. google-test will provide a more clear organization for tests that make writing tests easier (because you know where they should go) and finding tests (know what is or is not tested)

*Ease of Use*
Google has plenty of resources on how to use google-test, as well as google-mock. If anyone needs to find out how to write a unit test or take advantage of useful google-test features they can find all the resources they need online. google-test has a reasonably sized support community

*Standardization*
Google-test is an XUnit test framework which means we can pipe the output of the test runner into tons of tools that are already made to consume XUnit results. 

And all the other standard benefits...
- Automatic test discovery (scalability)
- Nice test output from the test runner
- Create custom semantic asserts
- Plugins for gtest to parallelize test runs

<img width="493" alt="screen shot 2016-08-11 at 12 34 35 am" src="https://cloud.githubusercontent.com/assets/458976/17581518/276dd55c-5f5b-11e6-8fcd-bf2036a7aa7c.png">