### PR TITLE
Set both ipv4 and ipv6 to 0 in Address::Clear()

### DIFF
--- a/yojimbo_address.cpp
+++ b/yojimbo_address.cpp
@@ -221,6 +221,7 @@ namespace yojimbo
     {
         m_type = ADDRESS_NONE;
         memset( m_address_ipv6, 0, sizeof( m_address_ipv6 ) );
+        m_address_ipv4 = 0;
         m_port = 0;
     }
 


### PR DESCRIPTION
This is a small consistency nitpick. I noticed in Address::Clear(), ipv6 was being set to 0 but ipv4 was not.