### PR TITLE
Bug fixes to serialize_enum(...) and UnreliableOrderedChannel::GetPacketData(...); Add missing functionality to Server and Client

### DIFF
--- a/yojimbo_channel.cpp
+++ b/yojimbo_channel.cpp
@@ -1347,6 +1347,8 @@ namespace yojimbo
 
         packetData.Initialize();
 
+        packetData.channelId = GetChannelId();
+
         packetData.message.numMessages = numMessages;
 
         packetData.message.messages = (Message**) YOJIMBO_ALLOCATE( allocator, sizeof( Message* ) * numMessages );

--- a/yojimbo_client.cpp
+++ b/yojimbo_client.cpp
@@ -223,7 +223,7 @@ namespace yojimbo
         return m_messageFactory->Create( type );
     }
 
-    bool Client::CanSendMsg()
+    bool Client::CanSendMsg( int channelId )
     {
         if ( !IsConnected() )
             return false;
@@ -231,18 +231,18 @@ namespace yojimbo
         assert( m_messageFactory );
         assert( m_connection );
         
-        return m_connection->CanSendMsg();
+        return m_connection->CanSendMsg( channelId );
     }
 
-    void Client::SendMsg( Message * message )
+    void Client::SendMsg( Message * message, int channelId )
     {
         assert( IsConnected() );
         assert( m_messageFactory );
         assert( m_connection );
-        m_connection->SendMsg( message );
+        m_connection->SendMsg( message, channelId );
     }
 
-    Message * Client::ReceiveMsg()
+    Message * Client::ReceiveMsg( int channelId )
     {
         assert( m_messageFactory );
 
@@ -251,7 +251,7 @@ namespace yojimbo
 
         assert( m_connection );
 
-        return m_connection->ReceiveMsg();
+        return m_connection->ReceiveMsg( channelId );
     }
 
     void Client::ReleaseMsg( Message * message )

--- a/yojimbo_client.h
+++ b/yojimbo_client.h
@@ -145,11 +145,11 @@ namespace yojimbo
 
         Message * CreateMsg( int type );
 
-        bool CanSendMsg();
+        bool CanSendMsg( int channelId = 0 );
 
-        void SendMsg( Message * message );
+        void SendMsg( Message * message, int channelId = 0 );
 
-        Message * ReceiveMsg();
+        Message * ReceiveMsg( int channelId = 0 );
 
         void ReleaseMsg( Message * message );
 

--- a/yojimbo_serialize.h
+++ b/yojimbo_serialize.h
@@ -84,10 +84,10 @@ namespace yojimbo
         {                                                               \
             uint32_t int_value = 0;                                     \
             if ( Stream::IsWriting )                                    \
-                int_value = value;                                      \
+                int_value = (uint32_t) value;                           \
             serialize_int( stream, int_value, 0, num_entries - 1 );     \
             if ( Stream::IsReading )                                    \
-                value = (type) value;                                   \
+                value = (type) int_value;                               \
         } while (0) 
 
     template <typename Stream> bool serialize_float_internal( Stream & stream, float & value )

--- a/yojimbo_server.cpp
+++ b/yojimbo_server.cpp
@@ -271,7 +271,7 @@ namespace yojimbo
         return m_clientMessageFactory[clientIndex]->Create( type );
     }
 
-    bool Server::CanSendMsg( int clientIndex ) const
+    bool Server::CanSendMsg( int clientIndex, int channelId ) const
     {
         assert( clientIndex >= 0 );
         assert( clientIndex < m_maxClients );
@@ -286,10 +286,10 @@ namespace yojimbo
         
         assert( m_clientConnection[clientIndex] );
 
-        return m_clientConnection[clientIndex]->CanSendMsg();
+        return m_clientConnection[clientIndex]->CanSendMsg( channelId );
     }
 
-    void Server::SendMsg( int clientIndex, Message * message )
+    void Server::SendMsg( int clientIndex, Message * message, int channelId )
     {
         assert( clientIndex >= 0 );
         assert( clientIndex < m_maxClients );
@@ -303,10 +303,10 @@ namespace yojimbo
 
         assert( m_clientConnection[clientIndex] );
 
-        m_clientConnection[clientIndex]->SendMsg( message );
+        m_clientConnection[clientIndex]->SendMsg( message, channelId );
     }
 
-    Message * Server::ReceiveMsg( int clientIndex )
+    Message * Server::ReceiveMsg( int clientIndex, int channelId )
     {
         assert( m_clientMessageFactory );
 
@@ -315,7 +315,7 @@ namespace yojimbo
 
         assert( m_clientConnection[clientIndex] );
 
-        return m_clientConnection[clientIndex]->ReceiveMsg();
+        return m_clientConnection[clientIndex]->ReceiveMsg( channelId );
     }
 
     void Server::ReleaseMsg( int clientIndex, Message * message )

--- a/yojimbo_server.h
+++ b/yojimbo_server.h
@@ -502,11 +502,11 @@ namespace yojimbo
 
         Message * CreateMsg( int clientIndex, int type );
 
-        bool CanSendMsg( int clientIndex ) const;
+        bool CanSendMsg( int clientIndex, int channelId = 0 ) const;
 
-        void SendMsg( int clientIndex, Message * message );
+        void SendMsg( int clientIndex, Message * message, int channelId = 0 );
 
-        Message * ReceiveMsg( int clientIndex );
+        Message * ReceiveMsg( int clientIndex, int channelId = 0 );
 
         void ReleaseMsg( int clientIndex, Message * message );
 


### PR DESCRIPTION
Wasn't sure if I should split these into multiple pull requests, so they're all in separate commits at least.

1. Fixes two issues with `serialize_enum` macro in yojimbo_serialize.h (lack of cast to uint32_t from input enum, and setting output value to value instead of int_value).
2. Fixes bug in `UnreliableOrderedChannel::GetPacketData(...)` where the channel ID of the outgoing ChannelPacketData was not set. If using more than 1 channel, and the Unreliable channel was not channel 0, this caused all sorts of asserts.
3. Added functionality to allow sending Messages to specific channels in Server and Client classes. Using this functionality in my own project is what had me find the issue in (2).