### PR TITLE
Check NDEBUG instead of DEBUG in yojimbo_bitpack.h

### DIFF
--- a/yojimbo_bitpack.h
+++ b/yojimbo_bitpack.h
@@ -313,9 +313,9 @@ namespace yojimbo
         uint64_t m_scratch;
         int m_numBits;
         int m_numBytes;
-#ifdef DEBUG
+#ifndef NDEBUG
         int m_numWords;
-#endif // #ifdef DEBUG
+#endif // #ifndef NDEBUG
         int m_bitsRead;
         int m_scratchBits;
         int m_wordIndex;


### PR DESCRIPTION
assert() checks NDEBUG not DEBUG, so associate parts should
also check NDEBUG.

Closes networkprotocol/libyojimbo#27