### PR TITLE
fix for memset typo in Server::ResetCounters

### DIFF
--- a/yojimbo_server.cpp
+++ b/yojimbo_server.cpp
@@ -605,7 +605,7 @@ namespace yojimbo
 
     void Server::ResetCounters()
     {
-        memset( m_counters, sizeof( m_counters ), 0 );
+        memset( m_counters, 0, sizeof( m_counters ) );
     }
 
     double Server::GetTime() const


### PR DESCRIPTION
The size and set arguments for memset are swapped in this case.  This pull request is simply swapping them to their correct positions.  I reviewed the other invocations of memset and did not find any more errors like this.