### PR TITLE
Fix missing namespace in server/client macros

### DIFF
--- a/yojimbo_client.h
+++ b/yojimbo_client.h
@@ -788,7 +788,7 @@ namespace yojimbo
  */
 
 #define YOJIMBO_CLIENT_ALLOCATOR( allocator_class )                                                     \
-    Allocator * CreateAllocator( Allocator & allocator, void * memory, size_t bytes )                   \
+    yojimbo::Allocator * CreateAllocator( yojimbo::Allocator & allocator, void * memory, size_t bytes ) \
     {                                                                                                   \
         return YOJIMBO_NEW( allocator, allocator_class, memory, bytes );                                \
     }
@@ -800,7 +800,7 @@ namespace yojimbo
  */
 
 #define YOJIMBO_CLIENT_PACKET_FACTORY( packet_factory_class )                                           \
-    PacketFactory * CreatePacketFactory( Allocator & allocator )                                        \
+    yojimbo::PacketFactory * CreatePacketFactory( yojimbo::Allocator & allocator )                      \
     {                                                                                                   \
         return YOJIMBO_NEW( allocator, packet_factory_class, allocator );                               \
     }
@@ -812,7 +812,7 @@ namespace yojimbo
  */
 
 #define YOJIMBO_CLIENT_MESSAGE_FACTORY( message_factory_class )                                         \
-    MessageFactory * CreateMessageFactory( Allocator & allocator )                                      \
+    yojimbo::MessageFactory * CreateMessageFactory( yojimbo::Allocator & allocator )                    \
     {                                                                                                   \
         return YOJIMBO_NEW( allocator, message_factory_class, allocator );                              \
     }

--- a/yojimbo_server.h
+++ b/yojimbo_server.h
@@ -949,10 +949,10 @@ namespace yojimbo
     See tests/shared.h for an example of usage.
  */
 
-#define YOJIMBO_SERVER_ALLOCATOR( allocator_class )                                                                     \
-    Allocator * CreateAllocator( Allocator & allocator, void * memory, size_t bytes )                                   \
-    {                                                                                                                   \
-        return YOJIMBO_NEW( allocator, allocator_class, memory, bytes );                                                \
+#define YOJIMBO_SERVER_ALLOCATOR( allocator_class )                                                                                         \
+    yojimbo::Allocator * CreateAllocator( yojimbo::Allocator & allocator, void * memory, size_t bytes )                                     \
+    {                                                                                                                                       \
+        return YOJIMBO_NEW( allocator, allocator_class, memory, bytes );                                                                    \
     }
 
 /** 
@@ -961,12 +961,12 @@ namespace yojimbo
     See tests/shared.h for an example of usage.
  */
 
-#define YOJIMBO_SERVER_PACKET_FACTORY( packet_factory_class )                                                           \
-    PacketFactory * CreatePacketFactory( Allocator & allocator, ServerResourceType type, int clientIndex )              \
-    {                                                                                                                   \
-        (void) type;                                                                                                    \
-        (void) clientIndex;                                                                                             \
-        return YOJIMBO_NEW( allocator, packet_factory_class, allocator );                                               \
+#define YOJIMBO_SERVER_PACKET_FACTORY( packet_factory_class )                                                                               \
+    yojimbo::PacketFactory * CreatePacketFactory( yojimbo::Allocator & allocator, yojimbo::ServerResourceType type, int clientIndex )       \
+    {                                                                                                                                       \
+        (void) type;                                                                                                                        \
+        (void) clientIndex;                                                                                                                 \
+        return YOJIMBO_NEW( allocator, packet_factory_class, allocator );                                                                   \
     }
 
 /** 
@@ -975,12 +975,12 @@ namespace yojimbo
     See tests/shared.h for an example of usage.
  */
 
-#define YOJIMBO_SERVER_MESSAGE_FACTORY( message_factory_class )                                                         \
-    MessageFactory * CreateMessageFactory( Allocator & allocator, ServerResourceType type, int clientIndex )            \
-    {                                                                                                                   \
-        (void) type;                                                                                                    \
-        (void) clientIndex;                                                                                             \
-        return YOJIMBO_NEW( allocator, message_factory_class, allocator );                                              \
+#define YOJIMBO_SERVER_MESSAGE_FACTORY( message_factory_class )                                                                             \
+    yojimbo::MessageFactory * CreateMessageFactory( yojimbo::Allocator & allocator, yojimbo::ServerResourceType type, int clientIndex )     \
+    {                                                                                                                                       \
+        (void) type;                                                                                                                        \
+        (void) clientIndex;                                                                                                                 \
+        return YOJIMBO_NEW( allocator, message_factory_class, allocator );                                                                  \
     }
 
 #endif // #ifndef YOJIMBO_SERVER_H


### PR DESCRIPTION
Maybe there are more left. 
But I'm not using yojimbo namespace in any of my headers and it works now. 