### PR TITLE
Silence possible C4005 warnings

### DIFF
--- a/yojimbo_config.h
+++ b/yojimbo_config.h
@@ -27,7 +27,7 @@
 
 /** @file */
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 


### PR DESCRIPTION
If the `_CRT_SECURE_NO_WARNINGS` macro is already set, then any include of the yojimbo headers will result in a spam of C4005 warnings;

```
1>...\libyojimbo\yojimbo_config.h(31): warning C4005: '_CRT_SECURE_NO_WARNINGS': macro redefinition
1>  ...\libyojimbo\yojimbo_config.h(31): note: command-line arguments:  see previous definition of '_CRT_SECURE_NO_WARNINGS'
```