### PR TITLE
Better endianness detection

### DIFF
--- a/yojimbo_config.h
+++ b/yojimbo_config.h
@@ -35,18 +35,52 @@
 #define YOJIMBO_MINOR_VERSION 4
 #define YOJIMBO_PATCH_VERSION 0
 
-#if    defined(__386__) || defined(i386)    || defined(__i386__)  \
-    || defined(__X86)   || defined(_M_IX86)                       \
-    || defined(_M_X64)  || defined(__x86_64__)                    \
-    || defined(alpha)   || defined(__alpha) || defined(__alpha__) \
-    || defined(_M_ALPHA)                                          \
-    || defined(ARM)     || defined(_ARM)    || defined(__arm__)   \
-    || defined(WIN32)   || defined(_WIN32)  || defined(__WIN32__) \
-    || defined(_WIN32_WCE) || defined(__NT__)                     \
-    || defined(__MIPSEL__)
-  #define YOJIMBO_LITTLE_ENDIAN 1
-#else
-  #define YOJIMBO_BIG_ENDIAN 1
+// Endianness detection from rapidjson
+#if !defined(YOJIMBO_LITTLE_ENDIAN) && !defined(YOJIMBO_BIG_ENDIAN)
+
+  #ifdef __BYTE_ORDER__
+    #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+      #define YOJIMBO_LITTLE_ENDIAN 1
+    #elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+      #define YOJIMBO_BIG_ENDIAN 1
+    #else
+      #error Unknown machine endianess detected. User needs to define YOJIMBO_LITTLE_ENDIAN or YOJIMBO_BIG_ENDIAN.
+    #endif // __BYTE_ORDER__
+  
+  // Detect with GLIBC's endian.h
+  #elif defined(__GLIBC__)
+    #include <endian.h>
+    #if (__BYTE_ORDER == __LITTLE_ENDIAN)
+      #define YOJIMBO_LITTLE_ENDIAN 1
+    #elif (__BYTE_ORDER == __BIG_ENDIAN)
+      #define YOJIMBO_BIG_ENDIAN 1
+    #else
+      #error Unknown machine endianess detected. User needs to define YOJIMBO_LITTLE_ENDIAN or YOJIMBO_BIG_ENDIAN.
+    #endif // __BYTE_ORDER
+  
+  // Detect with _LITTLE_ENDIAN and _BIG_ENDIAN macro
+  #elif defined(_LITTLE_ENDIAN) && !defined(_BIG_ENDIAN)
+    #define YOJIMBO_LITTLE_ENDIAN 1
+  #elif defined(_BIG_ENDIAN) && !defined(_LITTLE_ENDIAN)
+    #define YOJIMBO_BIG_ENDIAN 1
+  
+  // Detect with architecture macros
+  #elif    defined(__sparc)     || defined(__sparc__)                           \
+        || defined(_POWER)      || defined(__powerpc__)                         \
+        || defined(__ppc__)     || defined(__hpux)      || defined(__hppa)      \
+        || defined(_MIPSEB)     || defined(_POWER)      || defined(__s390__)
+    #define YOJIMBO_BIG_ENDIAN 1
+  #elif    defined(__i386__)    || defined(__alpha__)   || defined(__ia64)      \
+        || defined(__ia64__)    || defined(_M_IX86)     || defined(_M_IA64)     \
+        || defined(_M_ALPHA)    || defined(__amd64)     || defined(__amd64__)   \
+        || defined(_M_AMD64)    || defined(__x86_64)    || defined(__x86_64__)  \
+        || defined(_M_X64)      || defined(__bfin__)
+    #define YOJIMBO_LITTLE_ENDIAN 1
+  #elif defined(_MSC_VER) && defined(_M_ARM)
+    #define YOJIMBO_LITTLE_ENDIAN 1
+  #else
+    #error Unknown machine endianess detected. User needs to define YOJIMBO_LITTLE_ENDIAN or YOJIMBO_BIG_ENDIAN. 
+  #endif
 #endif
 
 #ifdef _MSC_VER


### PR DESCRIPTION
Changes:
1. Search for little or big endian defines, don't assume either option by default. If detection fails - emit a compiler error
2. Possible to pass YOJIMBO_BIG_ENDIAN or YOJIMBO_LITTLE_ENDIAN from build environment