### PR TITLE
Fix compilation issue when including yojimbo_client_server_packets.h alone

### DIFF
--- a/yojimbo_client_server_packets.h
+++ b/yojimbo_client_server_packets.h
@@ -28,6 +28,7 @@
 #include "yojimbo_config.h"
 #include "yojimbo_packet.h"
 #include "yojimbo_tokens.h"
+#include "yojimbo_connection.h"
 
 /** @file */
 


### PR DESCRIPTION
Missing include in yojimbo_client_server_packets.h to be standalone