### PR TITLE
Add a const getter for block message data

### DIFF
--- a/yojimbo_message.h
+++ b/yojimbo_message.h
@@ -322,6 +322,17 @@ namespace yojimbo
         }
 
         /**
+            Get a constant pointer to the block data.
+
+            @returns A constant pointer to the block data. NULL if no block is attached.
+         */
+
+        const uint8_t * GetBlockData() const
+        {
+            return m_blockData;
+        }
+
+        /**
             Get the size of the block attached to this message.
 
             @returns The size of the block (bytes). 0 if no block is attached.


### PR DESCRIPTION
As the title says.

Don't want to have to const_cast messages just to be able to read the data.