### PR TITLE
Avoid swap function redefinition

### DIFF
--- a/yojimbo_common.h
+++ b/yojimbo_common.h
@@ -142,14 +142,14 @@ namespace yojimbo
         @param a First value.
         @param b Second value.
      */
-
+#if __cplusplus < 201103L
     template <typename T> void swap( T & a, T & b )
     {
         T tmp = a;
         a = b;
         b = tmp;
     };
-
+#endif
     /**
         Get the absolute value.
 


### PR DESCRIPTION
The following code:
```
rce->server->yj_transport = std::make_unique<yojimbo::NetworkTransport>(
            yojimbo::GetDefaultAllocator(),
            yojimbo::Address(),
            PROTOCOL_VERSION,
            cur_time
    );
```
yields this error in GCC 6.3.1 on Linux
`error: call of overloaded ‘swap(yojimbo::NetworkTransport*&, yojimbo::NetworkTransport*&)’ is ambiguous`

It looks like the `swap` function in `yojimbo_common.h` is interfering with the swap function from the standard library.

This PR just removes the definition on C++11 or newer compilers using the `__cplusplus` macro. That being said, it's totally possible I'm doing something wrong, as both my C++ and knowledge of the standard are a little rusty these days.

Any thoughts?

Also thanks so much for this library, I expect to learn tons by studying and using it!